### PR TITLE
Better formatting for RegularModule.cs rendering of $encoded_wiki_*

### DIFF
--- a/plugins/wmib_rc/wmib_rc/RegularModule.cs
+++ b/plugins/wmib_rc/wmib_rc/RegularModule.cs
@@ -1,4 +1,4 @@
-?//This program is free software: you can redistribute it and/or modify
+//This program is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.


### PR DESCRIPTION
I added `.Replace("%3A", ":").Replace("%2F", "/").Replace("%28", "(").Replace("%29", ")")` to the stuff that is suppose to be wiki encoded so that it will look proper in [[]].  Undecided on what to do with "#", but it should probably never appear on its own.
