### PR TITLE
Adding brickimedia

### DIFF
--- a/configuration/linkie
+++ b/configuration/linkie
@@ -56,6 +56,7 @@ botwiki|https://botwiki.sno.cc/wiki/$1
 boxrec|https://www.boxrec.com/media/index.php?$1
 bpy|https://bpy.wikipedia.org/wiki/$1
 br|https://br.wikipedia.org/wiki/$1
+brickimedia|http://meta.brickimedia.org/wiki/$1
 brickwiki|https://brickwiki.org/index.php?title=$1
 bridgeswiki|https://c2.com:8000/$1
 bs|https://bs.wikipedia.org/wiki/$1


### PR DESCRIPTION
Hopefully this is okay to add, but Brickimedia is a wiki farm somewhat notable in the MediaWiki community; see https://www.mediawiki.org/wiki/Brickimedia
