### PR TITLE
Add toolforge to linkie

### DIFF
--- a/configuration/linkie
+++ b/configuration/linkie
@@ -562,6 +562,7 @@ to|https://to.wikipedia.org/wiki/$1
 tokipona|https://tokipona.wikipedia.org/wiki/$1
 tokyonights|https://wiki.tokyo-nights.com/wiki/$1
 tools|https://tools.wmflabs.org/$1
+toolforge|https://tools.wmflabs.org/$1
 toollabs|https://tools.wmflabs.org/$1
 tp|https://tp.wikipedia.org/wiki/$1
 tpi|https://tpi.wikipedia.org/wiki/$1


### PR DESCRIPTION
Does what it says on the tin. `[[toolforge:...]]` works on-wiki, so it should here, too.