### PR TITLE
Add ability to view and manage permissions for other channels without joining them

### DIFF
--- a/src/WMBot/Commands/Permissions.cs
+++ b/src/WMBot/Commands/Permissions.cs
@@ -16,19 +16,26 @@ namespace wmib
 {
     public partial class Commands
     {
-        public static bool Trusted(string message, string user, string host)
+        public static bool Trusted(string message, string user, string host, CommandParams parameters)
         {
             try
             {
                 if (message.StartsWith(Configuration.System.CommandPrefix + "trusted ", System.StringComparison.InvariantCulture))
                 {
-                    Channel ch = Core.GetChannel(message.Substring("xtrusted ".Length));
+                    Channel ch;
+                    if (parameters.Parameters != null) {
+                        string[] channel_info = parameters.Parameters.Split(' ');
+                        ch = core.GetChannel(channel_info[1]);
+                    }
+                    else {
+                        ch = Core.GetChannel(message.Substring("xtrusted ".Length));
+                    }
                     if (ch != null)
                     {
                         IRC.DeliverMessage(messages.Localize("TrustedUserList", ch.Language) + ch.SystemUsers.ListAll(), user);
                         return true;
                     }
-                    IRC.DeliverMessage("There is no such a channel I know of", user);
+                    IRC.DeliverMessage("Sorry, I'm not currently in that channel.", user);
                     return true;
                 }
             } catch (Exception fail)

--- a/src/WMBot/Commands/Permissions.cs
+++ b/src/WMBot/Commands/Permissions.cs
@@ -25,7 +25,7 @@ namespace wmib
                     Channel ch;
                     if (parameters.Parameters != null) {
                         string[] channel_info = parameters.Parameters.Split(' ');
-                        ch = core.GetChannel(channel_info[1]);
+                        ch = core.GetChannel(channel_info[0]);
                     }
                     else {
                         ch = Core.GetChannel(message.Substring("xtrusted ".Length));
@@ -47,6 +47,7 @@ namespace wmib
 
         private static void TrustAdd(CommandParams parameters)
         {
+            Channel chan;
             if (parameters.Parameters == null)
                 return;
             string[] rights_info = parameters.Parameters.Split(' ');
@@ -77,22 +78,50 @@ namespace wmib
                 IRC.DeliverMessage(messages.Localize("RoleMismatch", parameters.SourceChannel.Language), parameters.SourceChannel);
                 return;
             }
-            if (parameters.SourceChannel.SystemUsers.AddUser(rights_info[1], rights_info[0]))
+            if (rights_info[2] != null) {
+                if ( channel.SystemUsers.IsApproved(invoker, "root") {
+                    chan = core.GetChannel(rights_info[2]);
+                }
+                else {
+                    IRC.DeliverMessage("Sorry, only root users can manage permissions for other channels.", parameters.SourceChannel);
+                    return;
+                }
+            }
+            else {
+                chan = parameters.SourceChannel;
+            }
+            if (chan.SystemUsers.AddUser(rights_info[1], rights_info[0]))
             {
                 IRC.DeliverMessage(messages.Localize("UserSc", parameters.SourceChannel.Language) + rights_info[0], parameters.SourceChannel);
+                if ( rights_info[2] != null ) {
+                    IRC.DeliverMessage(rights_info[0] + ", was added to the trust list in this channel. (" + parameters.SourceChannel + ")", chan);
+                }
                 return;
             }
         }
 
         private static void TrustDel(CommandParams parameters)
         {
-            if (string.IsNullOrEmpty(parameters.Parameters))
+            Channel chan;
+            string[] rights_info = parameters.Parameters.Split(' ');
+            if (rights_info[0] = null)
             {
                 IRC.DeliverMessage(messages.Localize("InvalidUser", parameters.SourceChannel.Language), parameters.SourceChannel);
                 return;
             }
-            string rights_info = parameters.Parameters.Trim();
-            parameters.SourceChannel.SystemUsers.DeleteUser(parameters.SourceChannel.SystemUsers.GetUser(parameters.User), rights_info);
+            if (rights_info[1] != null) {
+                if ( channel.SystemUsers.IsApproved(invoker, "root") {
+                    chan = core.GetChannel(rights_info[1]);
+                }
+                else {
+                    IRC.DeliverMessage("Sorry, only root users can manage permissions for other channels.", parameters.SourceChannel);
+                    return;
+                }
+            }
+            else {
+                chan = parameters.SourceChannel;
+            }
+            chan.SystemUsers.DeleteUser(parameters.SourceChannel.SystemUsers.GetUser(parameters.User), rights_info[0]);
             return;
         }
 

--- a/src/WMBot/Commands/Permissions.cs
+++ b/src/WMBot/Commands/Permissions.cs
@@ -104,7 +104,7 @@ namespace wmib
         {
             Channel chan;
             string[] rights_info = parameters.Parameters.Split(' ');
-            if (rights_info[0] = null)
+            if (rights_info[0] == null)
             {
                 IRC.DeliverMessage(messages.Localize("InvalidUser", parameters.SourceChannel.Language), parameters.SourceChannel);
                 return;


### PR DESCRIPTION
This will solve the problem of the bot being added to a private channel for a user who doesn't have a wikimedia/miraheze cloak. Currently the only way to modify permissions for a channel is to join said channel and run @trustadd or @trustdel. This would allow modification from other channels such as #wm-bot, while still working as normal when no channel is provided in the commands.

**@trusted**
@trusted (channel) will return the trustlist for (channel)
@trusted still returns the trustlist for the current channel

**@trustadd**
@trustadd (regex/username) (role) will still grant (role) to (regex/username)
@trustadd (regex/username) (role) (channel) will grant (role) to (regex/username) in (channel) - This can only be done by root users, and the bot will say in (channel) that the trustlist was modified

**trustdel**
@trustdel (regex/username) still deletes (regex/username) from the trustlist in the current channel
@ trustdel (regex/username) (channel) deletes (regex/username) from the trustlist in (channel) - this can only be done by root users