### PR TITLE
logs: Fix broken gh-fork-ribbon.min.css link

### DIFF
--- a/public_html/logs/index.php
+++ b/public_html/logs/index.php
@@ -27,9 +27,9 @@ $html->Style->items['*']['font-family'] = 'Open Sans';
 $html->AppendHtml('<a class="github-fork-ribbon right-top" href="https://github.com/benapetr/wikimedia-bot/tree/master/public_html/logs" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>');
 $html->ExternalCss[] = "style/style.css";
 $html->ExternalCss[] = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.10.3/themes/smoothness/jquery-ui.min.css";
+$html->ExternalCss[] = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css";
 $html->ExternalJs[] = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.9.1/jquery.min.js";
 $html->ExternalJs[] = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js";
-$html->ExternalJs[] = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css";
 
 // Header
 $header = "Wikimedia IRC logs browser";


### PR DESCRIPTION
This was incorrectly loaded as a script, which produces an error and no styling.